### PR TITLE
Addition of polyglot docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ $ cd docker-tornadovm
 $ ./polyglotImages/polyglot-graalpy/tornadovm-polyglot.sh
 
 ## Run Matrix Multiplication from a Python program.
-$ ./polyglotImages/polyglot-graalpy/tornadovm-polyglot.sh tornado --printKernel --truffle python /tornado-dev/tornado/bin/sdk/examples/polyglotTruffle/mxmWithTornadoVM.py
+$ ./polyglotImages/polyglot-graalpy/tornadovm-polyglot.sh tornado --printKernel --truffle python example/polyglot-examples/mxmWithTornadoVM.py
 ```
 
 * JavaScript:
@@ -194,7 +194,7 @@ $ cd docker-tornadovm
 $ ./polyglotImages/polyglot-graaljs/tornadovm-polyglot.sh
 
 ## Run Matrix Multiplication from a JavaScript program.
-$ ./polyglotImages/polyglot-graaljs/tornadovm-polyglot.sh tornado --printKernel --truffle js /tornado-dev/tornado/bin/sdk/examples/polyglotTruffle/mxmWithTornadoVM.js
+$ ./polyglotImages/polyglot-graaljs/tornadovm-polyglot.sh tornado --printKernel --truffle js example/polyglot-examples/mxmWithTornadoVM.js
 ```
 
 * Ruby:
@@ -206,7 +206,7 @@ $ cd docker-tornadovm
 $ ./polyglotImages/polyglot-truffleruby/tornadovm-polyglot.sh
 
 ## Run Matrix Multiplication from a Python program.
-$ ./polyglotImages/polyglot-truffleruby/tornadovm-polyglot.sh tornado --printKernel --truffle ruby /tornado-dev/tornado/bin/sdk/examples/polyglotTruffle/mxmWithTornadoVM.rb
+$ ./polyglotImages/polyglot-truffleruby/tornadovm-polyglot.sh tornado --printKernel --truffle ruby example/polyglot-examples/mxmWithTornadoVM.rb
 ```
 
 

--- a/example/polyglot-examples/mxmWithTornadoVM.js
+++ b/example/polyglot-examples/mxmWithTornadoVM.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+console.log("Hello TornadoVM from JavaScript!")
+
+for (var i = 0; i < 5; i++) {
+    var myclass = Java.type('uk.ac.manchester.tornado.examples.polyglot.MyCompute')
+    var start = new Date().getTime() / 1000;
+    myclass.compute()
+    var end = new Date().getTime() / 1000;
+    console.log("Total Time (s): " + (end - start))
+}

--- a/example/polyglot-examples/mxmWithTornadoVM.py
+++ b/example/polyglot-examples/mxmWithTornadoVM.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2023, APT Group, Department of Computer Science,
+# The University of Manchester.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+#!/usr/bin/python
+
+import java
+import time
+
+myclass = java.type("uk.ac.manchester.tornado.examples.polyglot.MyCompute")
+
+print("Hello TornadoVM from Python!")
+
+for i in range(5):
+    start = time.time()
+    output = myclass.compute()
+    end = time.time()
+    print("Total time (s): " + str((end - start)))

--- a/example/polyglot-examples/mxmWithTornadoVM.rb
+++ b/example/polyglot-examples/mxmWithTornadoVM.rb
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2023, APT Group, Department of Computer Science,
+# The University of Manchester.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+myclass = Java.type('uk.ac.manchester.tornado.examples.polyglot.MyCompute')
+
+puts("Hello TornadoVM from Ruby!")
+for a in 1..5 do
+    startTime = Time.now()
+    myclass.compute()
+    endTime = Time.now()
+    print("Total time (s): ", endTime - startTime)
+    puts
+end

--- a/polyglotImages/README.md
+++ b/polyglotImages/README.md
@@ -1,6 +1,6 @@
 # docker-tornadovm and Polyglot GraalVM implementations
 Docker build scripts for running Polyglot GraalVM implementations (e.g., GraalPython, GraalJS) with TornadoVM on GPUs.
-The docker images use [TornadoVM (GraalVM 23.1.0)](https://github.com/beehive-lab/TornadoVM/commit/fe269d9b16d9b0b1ac981c80dfec2a5cf7c14206) along with GraalPython ([tag: graal-23.1.0](https://github.com/oracle/graalpython/releases/tag/graal-23.1.0)) and GraalJS ([tag: graal-23.1.0](https://github.com/oracle/graaljs/releases/tag/graal-23.1.0)). The images contain the installation of [OpenCL driver for Nvidia GPUs]().
+The docker images use [TornadoVM (GraalVM 23.1.0)](https://github.com/beehive-lab/TornadoVM/commit/fe269d9b16d9b0b1ac981c80dfec2a5cf7c14206) along with GraalPython ([tag: graal-23.1.0](https://github.com/oracle/graalpython/releases/tag/graal-23.1.0)) and GraalJS ([tag: graal-23.1.0](https://github.com/oracle/graaljs/releases/tag/graal-23.1.0)) and TruffleRuby ([tag: graal-23.1.0](https://github.com/oracle/truffleruby/releases/tag/graal-23.1.0)). The images contain the installation of [OpenCL driver for Nvidia GPUs]().
 
 ## Build docker images
 To build the container you can use a script as follows:

--- a/polyglotImages/README.md
+++ b/polyglotImages/README.md
@@ -1,0 +1,108 @@
+# docker-tornadovm-polyglot
+Docker build scripts for running Polyglot GraalVM implementations (e.g., GraalPython, GraalJS) with TornadoVM on GPUs.
+The docker images use [TornadoVM (GraalVM 23.1.0)](https://github.com/beehive-lab/TornadoVM/commit/fe269d9b16d9b0b1ac981c80dfec2a5cf7c14206) along with GraalPython ([tag: graal-23.1.0](https://github.com/oracle/graalpython/releases/tag/graal-23.1.0)) and GraalJS ([tag: graal-23.1.0](https://github.com/oracle/graaljs/releases/tag/graal-23.1.0)). The images contain the installation of [OpenCL driver for Nvidia GPUs]().
+
+## Build docker images
+To build the container you can use a script as follows:
+```bash
+./buildDocker.sh --help
+Please run:
+  ./buildDocker.sh --python           to create a volume and build the docker image for tornadovm-graalpy, or
+  ./buildDocker.sh --js               to create a volume and build the docker image for tornadovm-graaljs, or
+  ./buildDocker.sh --all              to create a volume and build all docker images, or
+  ./buildDocker.sh --deleteVolume     to delete the generated volume, or
+  ./buildDocker.sh --help             to print help message
+```
+
+To build all images, try:
+```bash
+./buildDocker.sh --all
+```
+
+## Run examples
+To run an example of a Python program from [here](https://github.com/beehive-lab/TornadoVM/blob/master/tornado-assembly/src/examples/polyglotTruffle/mxmWithTornadoVM.py) in the container with TornadoVM use:
+```bash
+./polyglot-graalpy/tornadovm-polyglot.sh tornado --printKernel --truffle python /tornado-dev/tornado/bin/sdk/examples/polyglotTruffle/mxmWithTornadoVM.py
+```
+The output will be:
+```bash
+WARNING: Using incubator modules: jdk.incubator.vector
+Running with tornadoVM
+Hello TornadoVM from Python!
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable  
+#pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable  
+__kernel void mxm(__global long *_kernel_context, __constant uchar *_constant_region, __local uchar *_local_region, __global int *_atomics, __global uchar *a, __global uchar *b, __global uchar *c, __private int N)
+{
+  int i_28, i_27, i_19, i_13, i_12, i_10, i_9, i_8, i_7, i_6, i_5, i_4, i_3, i_34, i_33; 
+  ulong ul_23, ul_2, ul_1, ul_17, ul_0, ul_32; 
+  float f_24, f_25, f_18, f_26, f_11; 
+  long l_29, l_14, l_30, l_21, l_22, l_20, l_15, l_31, l_16; 
+
+  // BLOCK 0
+  ul_0  =  (ulong) a;
+  ul_1  =  (ulong) b;
+  ul_2  =  (ulong) c;
+  i_3  =  get_global_size(0);
+  i_4  =  get_global_size(1);
+  i_5  =  get_global_id(0);
+  i_6  =  get_global_id(1);
+  // BLOCK 1 MERGES [0 8 ]
+  i_7  =  i_6;
+  for(;i_7 < 512;)
+  {
+    // BLOCK 2
+    i_8  =  i_7 << 9;
+    // BLOCK 3 MERGES [2 7 ]
+    i_9  =  i_5;
+    for(;i_9 < 512;)
+    {
+      // BLOCK 4
+      i_10  =  i_9 + 512;
+      // BLOCK 5 MERGES [4 6 ]
+      f_11  =  0.0F;
+      i_12  =  0;
+      for(;i_12 < 512;)
+      {
+        // BLOCK 6
+        i_13  =  i_8 + i_12;
+        l_14  =  (long) i_13;
+        l_15  =  l_14 << 2;
+        l_16  =  l_15 + 24L;
+        ul_17  =  ul_0 + l_16;
+        f_18  =  *((__global float *) ul_17);
+        i_19  =  i_10 + i_12;
+        l_20  =  (long) i_19;
+        l_21  =  l_20 << 2;
+        l_22  =  l_21 + 24L;
+        ul_23  =  ul_1 + l_22;
+        f_24  =  *((__global float *) ul_23);
+        f_25  =  f_18 + f_24;
+        f_26  =  f_11 + f_25;
+        i_27  =  i_12 + 1;
+        f_11  =  f_26;
+        i_12  =  i_27;
+      }  // B6
+      // BLOCK 7
+      i_28  =  i_9 + i_8;
+      l_29  =  (long) i_28;
+      l_30  =  l_29 << 2;
+      l_31  =  l_30 + 24L;
+      ul_32  =  ul_2 + l_31;
+      *((__global float *) ul_32)  =  f_11;
+      i_33  =  i_3 + i_9;
+      i_9  =  i_33;
+    }  // B7
+    // BLOCK 8
+    i_34  =  i_4 + i_7;
+    i_7  =  i_34;
+  }  // B8
+  // BLOCK 9
+  return;
+}  //  kernel
+
+Total time (s): 0.5230000019073486
+Total time (s): 0.006999969482421875
+Total time (s): 0.003000020980834961
+Total time (s): 0.002000093460083008
+Total time (s): 0.0019998550415039062
+```

--- a/polyglotImages/README.md
+++ b/polyglotImages/README.md
@@ -1,4 +1,4 @@
-# docker-tornadovm and Polyglot GraalVM implementations
+# docker-tornadovm and Polyglot GraalVM Language Implementations
 Docker build scripts for running Polyglot GraalVM implementations (e.g., GraalPython, GraalJS) with TornadoVM on GPUs.
 The docker images use [TornadoVM (GraalVM 23.1.0)](https://github.com/beehive-lab/TornadoVM/commit/fe269d9b16d9b0b1ac981c80dfec2a5cf7c14206) along with GraalPython ([tag: graal-23.1.0](https://github.com/oracle/graalpython/releases/tag/graal-23.1.0)) and GraalJS ([tag: graal-23.1.0](https://github.com/oracle/graaljs/releases/tag/graal-23.1.0)) and TruffleRuby ([tag: graal-23.1.0](https://github.com/oracle/truffleruby/releases/tag/graal-23.1.0)). The images contain the installation of [OpenCL driver for Nvidia GPUs]().
 

--- a/polyglotImages/README.md
+++ b/polyglotImages/README.md
@@ -1,4 +1,4 @@
-# docker-tornadovm-polyglot
+# docker-tornadovm and Polyglot GraalVM implementations
 Docker build scripts for running Polyglot GraalVM implementations (e.g., GraalPython, GraalJS) with TornadoVM on GPUs.
 The docker images use [TornadoVM (GraalVM 23.1.0)](https://github.com/beehive-lab/TornadoVM/commit/fe269d9b16d9b0b1ac981c80dfec2a5cf7c14206) along with GraalPython ([tag: graal-23.1.0](https://github.com/oracle/graalpython/releases/tag/graal-23.1.0)) and GraalJS ([tag: graal-23.1.0](https://github.com/oracle/graaljs/releases/tag/graal-23.1.0)). The images contain the installation of [OpenCL driver for Nvidia GPUs]().
 
@@ -9,6 +9,7 @@ To build the container you can use a script as follows:
 Please run:
   ./buildDocker.sh --python           to create a volume and build the docker image for tornadovm-graalpy, or
   ./buildDocker.sh --js               to create a volume and build the docker image for tornadovm-graaljs, or
+  ./buildDocker.sh --ruby             to create a volume and build the docker image for tornadovm-truffleruby, or
   ./buildDocker.sh --all              to create a volume and build all docker images, or
   ./buildDocker.sh --deleteVolume     to delete the generated volume, or
   ./buildDocker.sh --help             to print help message

--- a/polyglotImages/buildDocker.sh
+++ b/polyglotImages/buildDocker.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+if [[ "$1" == "--python" ]]; then
+    docker volume create data
+    docker build -f ./polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21 -t tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container .
+elif [[ "$1" == "--js" ]]; then
+    docker volume create data
+    docker build -f ./polyglot-graaljs/Dockerfile.nvidia.opencl.graaljs.jdk21 -t tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container .
+elif [[ "$1" == "--ruby" ]]; then
+    docker volume create data
+    docker build -f ./polyglot-truffleruby/Dockerfile.nvidia.opencl.truffleruby.jdk21 -t tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container .
+elif [[ "$1" == "--deleteVolume" ]]; then
+    docker volume rm data
+elif [[ "$1" == "--all" ]]; then
+    docker volume create data
+    docker build -f ./polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21 --no-cache -t tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container .
+    docker build -f ./polyglot-graaljs/Dockerfile.nvidia.opencl.graaljs.jdk21 --no-cache -t tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container .
+    docker build -f ./polyglot-truffleruby/Dockerfile.nvidia.opencl.truffleruby.jdk21 --no-cache -t tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container .
+elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
+    echo "Please run:"
+    echo "  ./buildDocker.sh --python		to create a volume and build the docker image for tornadovm-graalpy, or"
+    echo "  ./buildDocker.sh --js		to create a volume and build the docker image for tornadovm-graaljs, or"
+    echo "  ./buildDocker.sh --ruby		to create a volume and build the docker image for tornadovm-truffleruby, or"
+    echo "  ./buildDocker.sh --all		to create a volume and build all docker images, or"
+    echo "  ./buildDocker.sh --deleteVolume	to delete the generated volume, or"
+    echo "  ./buildDocker.sh --help		to print help message"
+else
+    echo "Please run:"
+    echo "  ./buildDocker.sh --python           to create a volume and build the docker image for tornadovm-graalpy, or"
+    echo "  ./buildDocker.sh --js               to create a volume and build the docker image for tornadovm-graaljs, or"
+    echo "  ./buildDocker.sh --ruby             to create a volume and build the docker image for tornadovm-truffleruby, or"
+    echo "  ./buildDocker.sh --all              to create a volume and build all docker images, or"
+    echo "  ./buildDocker.sh --deleteVolume     to delete the generated volume, or"
+    echo "  ./buildDocker.sh --help             to print help message"
+fi

--- a/polyglotImages/buildDocker.sh
+++ b/polyglotImages/buildDocker.sh
@@ -1,21 +1,32 @@
 #!/usr/bin/env bash
 
+TAG_VERSION=0.15.2-dev
+
+function buildDockerImage() {
+    IMAGE=$1
+    FILE=$2
+    docker build -t $IMAGE -f $FILE .
+    docker tag $IMAGE beehivelab/$IMAGE:$TAG_VERSION
+    docker tag $IMAGE beehivelab/$IMAGE:latest
+}
+
+
 if [[ "$1" == "--python" ]]; then
     docker volume create data
-    docker build -f ./polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21 -t tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container .
+    buildDockerImage "tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container" "./polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21"
 elif [[ "$1" == "--js" ]]; then
     docker volume create data
-    docker build -f ./polyglot-graaljs/Dockerfile.nvidia.opencl.graaljs.jdk21 -t tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container .
+    buildDockerImage "tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container" "./polyglot-graaljs/Dockerfile.nvidia.opencl.graaljs.jdk21"
 elif [[ "$1" == "--ruby" ]]; then
     docker volume create data
-    docker build -f ./polyglot-truffleruby/Dockerfile.nvidia.opencl.truffleruby.jdk21 -t tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container .
+    buildDockerImage "tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container" "./polyglot-truffleruby/Dockerfile.nvidia.opencl.truffleruby.jdk21"
 elif [[ "$1" == "--deleteVolume" ]]; then
     docker volume rm data
 elif [[ "$1" == "--all" ]]; then
     docker volume create data
-    docker build -f ./polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21 --no-cache -t tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container .
-    docker build -f ./polyglot-graaljs/Dockerfile.nvidia.opencl.graaljs.jdk21 --no-cache -t tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container .
-    docker build -f ./polyglot-truffleruby/Dockerfile.nvidia.opencl.truffleruby.jdk21 --no-cache -t tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container .
+    buildDockerImage "tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container" "./polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21"
+    buildDockerImage "tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container" "./polyglot-graaljs/Dockerfile.nvidia.opencl.graaljs.jdk21"
+    buildDockerImage "tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container" "./polyglot-truffleruby/Dockerfile.nvidia.opencl.truffleruby.jdk21"
 elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
     echo "Please run:"
     echo "  ./buildDocker.sh --python		to create a volume and build the docker image for tornadovm-graalpy, or"

--- a/polyglotImages/polyglot-graaljs/Dockerfile.nvidia.opencl.graaljs.jdk21
+++ b/polyglotImages/polyglot-graaljs/Dockerfile.nvidia.opencl.graaljs.jdk21
@@ -1,0 +1,57 @@
+## Docker File for TornadoVM on NVIDIA GPUs using GraalVM 23.1.0 JDK21
+## OpenCL Backend only
+
+FROM ubuntu:22.04
+
+LABEL MAINTAINER Thanos Stratikopoulos <athanasios.stratikopoulos@manchester.ac.uk>
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update -q && apt-get install -qy \
+        build-essential vim git cmake maven openjdk-17-jdk python3 python3-pip \
+        wget clinfo ocl-icd-opencl-dev opencl-headers && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install wget
+
+ENV PATH /usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
+
+# Enable Nvidia OpenCL
+RUN mkdir -p /etc/OpenCL/vendors && \
+    echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+# Install GraalJS
+WORKDIR /graaljs-dev/
+RUN git clone https://github.com/oracle/graal /graaljs-dev/graal && cd /graaljs-dev/graal && git checkout f795ef233f3e325aab46db7241f367b6c88de1b0
+RUN git clone https://github.com/oracle/graaljs.git /graaljs-dev/graaljs && cd /graaljs-dev/graaljs && git checkout graal-23.1.0
+WORKDIR /graaljs-dev/graaljs
+RUN git clone https://github.com/graalvm/mx.git /graaljs-dev/mx
+RUN wget -O /tmp/labsjdk-ce-21.0.1+12-jvmci-23.1-b22-linux-amd64.tar.gz https://github.com/graalvm/labs-openjdk-21/releases/download/jvmci-23.1-b22/labsjdk-ce-21.0.1+12-jvmci-23.1-b22-linux-amd64.tar.gz
+RUN mkdir -p /root/.mx/jdks/ \
+    && tar xzvf /tmp/labsjdk-ce-21.0.1+12-jvmci-23.1-b22-linux-amd64.tar.gz --directory /root/.mx/jdks/
+ENV MX_PYTHON_VERSION=3
+WORKDIR /graaljs-dev/graaljs/graal-js
+ENV JAVA_HOME=/root/.mx/jdks/labsjdk-ce-21.0.1-jvmci-23.1-b22
+RUN /graaljs-dev/mx/mx --dynamicimports /compiler build
+
+## Install TornadoVM 
+WORKDIR /tornado-dev/
+RUN git clone https://github.com/beehive-lab/TornadoVM.git tornado && cd tornado && git checkout master
+WORKDIR /tornado-dev/tornado
+ENV CMAKE_ROOT=/usr
+RUN ./bin/tornadovm-installer --jdk graalvm-jdk-21 --backend opencl --polyglot 
+SHELL ["/bin/bash", "-c", "source /tornado/tornado/setvars.sh"]
+
+## ENV-Variables Taken from the SOURCE.sh
+ENV JAVA_HOME=/tornado-dev/tornado/etc/dependencies/TornadoVM-graalvm-jdk-21/graalvm-community-openjdk-21.0.1+12.1
+ENV PATH=/tornado-dev/tornado/bin/bin:$PATH
+ENV TORNADO_SDK=/tornado-dev/tornado/bin/sdk
+ENV TORNADO_ROOT=/tornado-dev/tornado 
+ENV GRAALJS_HOME=/graaljs-dev/graal/sdk/mxbuild/linux-amd64/GRAALVM_3AF13F6F38_JAVA21/graalvm-3af13f6f38-java21-23.1.0-dev
+
+## Final Setup
+WORKDIR /data
+VOLUME ["/data"]
+EXPOSE 3000 

--- a/polyglotImages/polyglot-graaljs/tornadovm-polyglot.sh
+++ b/polyglotImages/polyglot-graaljs/tornadovm-polyglot.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [[ "$1" == "--console" ]]; then
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container
+elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
+    echo "Please run:"
+    echo "  ./tornadovm-polyglot.sh --console		to launch the built image in which GraalJS interoperates with TornadoVM, or"
+    echo "  ./tornadovm-polyglot.sh <command>		to launch the built image or execute a JavaScript program that interoperates with TornadoVM, or"
+    echo "  ./tornadovm-polyglot.sh --help		to print help message"
+else
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container "$@"
+fi

--- a/polyglotImages/polyglot-graaljs/tornadovm-polyglot.sh
+++ b/polyglotImages/polyglot-graaljs/tornadovm-polyglot.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 if [[ "$1" == "--console" ]]; then
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container
 elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
     echo "Please run:"
     echo "  ./tornadovm-polyglot.sh --console		to launch the built image in which GraalJS interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh <command>		to launch the built image or execute a JavaScript program that interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh --help		to print help message"
 else
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container "$@"
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container "$@"
 fi

--- a/polyglotImages/polyglot-graaljs/tornadovm-polyglot.sh
+++ b/polyglotImages/polyglot-graaljs/tornadovm-polyglot.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 if [[ "$1" == "--console" ]]; then
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container:latest
 elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
     echo "Please run:"
     echo "  ./tornadovm-polyglot.sh --console		to launch the built image in which GraalJS interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh <command>		to launch the built image or execute a JavaScript program that interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh --help		to print help message"
 else
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container "$@"
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container:latest "$@"
 fi

--- a/polyglotImages/polyglot-graaljs/tornadovm-polyglot.sh
+++ b/polyglotImages/polyglot-graaljs/tornadovm-polyglot.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 if [[ "$1" == "--console" ]]; then
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container:latest
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v "$PWD":/data beehivelab/tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container:latest
 elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
     echo "Please run:"
     echo "  ./tornadovm-polyglot.sh --console		to launch the built image in which GraalJS interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh <command>		to launch the built image or execute a JavaScript program that interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh --help		to print help message"
 else
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container:latest "$@"
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v "$PWD":/data beehivelab/tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container:latest "$@"
 fi

--- a/polyglotImages/polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21
+++ b/polyglotImages/polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21
@@ -1,0 +1,58 @@
+## Docker File for TornadoVM on NVIDIA GPUs using GraalVM 23.1.0 JDK21
+## OpenCL Backend only
+
+#FROM nvidia/opencl
+FROM ubuntu:22.04
+
+LABEL MAINTAINER Thanos Stratikopoulos <athanasios.stratikopoulos@manchester.ac.uk>
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update -q && apt-get install -qy \
+        build-essential vim git cmake maven openjdk-17-jdk python3 python3-pip \
+        wget clinfo ocl-icd-opencl-dev opencl-headers && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install wget
+
+ENV PATH /usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
+
+# Enable Nvidia OpenCL
+RUN mkdir -p /etc/OpenCL/vendors && \
+    echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+# Install GraalPy
+WORKDIR /graalpy-dev/
+RUN git clone https://github.com/oracle/graal /graalpy-dev/graal && cd /graalpy-dev/graal && git checkout 5a21d6dd0051ff99f561d89dfc530d723edb3ab8
+RUN git clone https://github.com/oracle/graalpython.git /graalpy-dev/graalpython && cd /graalpy-dev/graalpython && git checkout graal-23.1.0
+WORKDIR /graalpy-dev/graalpython
+RUN git clone https://github.com/graalvm/mx.git /graalpy-dev/graalpython/mx
+RUN wget -O /tmp/labsjdk-ce-21.0.1+12-jvmci-23.1-b22-linux-amd64.tar.gz https://github.com/graalvm/labs-openjdk-21/releases/download/jvmci-23.1-b22/labsjdk-ce-21.0.1+12-jvmci-23.1-b22-linux-amd64.tar.gz
+RUN mkdir -p /root/.mx/jdks/ \
+    && tar xzvf /tmp/labsjdk-ce-21.0.1+12-jvmci-23.1-b22-linux-amd64.tar.gz --directory /root/.mx/jdks/
+ENV MX_PYTHON_VERSION=3
+WORKDIR /graalpy-dev/graalpython/
+ENV JAVA_HOME=/root/.mx/jdks/labsjdk-ce-21.0.1-jvmci-23.1-b22
+RUN mx/mx --dy /compiler python-gvm
+
+## Install TornadoVM 
+WORKDIR /tornado-dev/
+RUN git clone https://github.com/beehive-lab/TornadoVM.git tornado && cd tornado && git checkout master
+WORKDIR /tornado-dev/tornado
+ENV CMAKE_ROOT=/usr
+RUN ./bin/tornadovm-installer --jdk graalvm-jdk-21 --backend opencl --polyglot 
+SHELL ["/bin/bash", "-c", "source /tornado/tornado/setvars.sh"]
+
+## ENV-Variables Taken from the SOURCE.sh
+ENV JAVA_HOME=/tornado-dev/tornado/etc/dependencies/TornadoVM-graalvm-jdk-21/graalvm-community-openjdk-21.0.1+12.1
+ENV PATH=/tornado-dev/tornado/bin/bin:$PATH
+ENV TORNADO_SDK=/tornado-dev/tornado/bin/sdk
+ENV TORNADO_ROOT=/tornado-dev/tornado 
+ENV GRAALPY_HOME=/graalpy-dev/graal/sdk/mxbuild/linux-amd64/GRAALVM_03DCD25EA1_JAVA21/graalvm-03dcd25ea1-java21-23.1.0-dev
+
+## Final Setup
+WORKDIR /data
+VOLUME ["/data"]
+EXPOSE 3000 

--- a/polyglotImages/polyglot-graalpy/tornadovm-polyglot.sh
+++ b/polyglotImages/polyglot-graalpy/tornadovm-polyglot.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 if [[ "$1" == "--console" ]]; then
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container
 elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
     echo "Please run:"
     echo "  ./tornadovm-polyglot.sh --console		to launch the built image in which GraalPy interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh <command>		to launch the built image or execute a Python program that interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh --help		to print help message"
 else
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container "$@"
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container "$@"
 fi

--- a/polyglotImages/polyglot-graalpy/tornadovm-polyglot.sh
+++ b/polyglotImages/polyglot-graalpy/tornadovm-polyglot.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [[ "$1" == "--console" ]]; then
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container
+elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
+    echo "Please run:"
+    echo "  ./tornadovm-polyglot.sh --console		to launch the built image in which GraalPy interoperates with TornadoVM, or"
+    echo "  ./tornadovm-polyglot.sh <command>		to launch the built image or execute a Python program that interoperates with TornadoVM, or"
+    echo "  ./tornadovm-polyglot.sh --help		to print help message"
+else
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container "$@"
+fi

--- a/polyglotImages/polyglot-graalpy/tornadovm-polyglot.sh
+++ b/polyglotImages/polyglot-graalpy/tornadovm-polyglot.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 if [[ "$1" == "--console" ]]; then
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container:latest
 elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
     echo "Please run:"
     echo "  ./tornadovm-polyglot.sh --console		to launch the built image in which GraalPy interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh <command>		to launch the built image or execute a Python program that interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh --help		to print help message"
 else
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container "$@"
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container:latest "$@"
 fi

--- a/polyglotImages/polyglot-graalpy/tornadovm-polyglot.sh
+++ b/polyglotImages/polyglot-graalpy/tornadovm-polyglot.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 if [[ "$1" == "--console" ]]; then
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container:latest
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v "$PWD":/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container:latest
 elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
     echo "Please run:"
     echo "  ./tornadovm-polyglot.sh --console		to launch the built image in which GraalPy interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh <command>		to launch the built image or execute a Python program that interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh --help		to print help message"
 else
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container:latest "$@"
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v "$PWD":/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container:latest "$@"
 fi

--- a/polyglotImages/polyglot-truffleruby/Dockerfile.nvidia.opencl.truffleruby.jdk21
+++ b/polyglotImages/polyglot-truffleruby/Dockerfile.nvidia.opencl.truffleruby.jdk21
@@ -1,0 +1,61 @@
+## Docker File for TornadoVM on NVIDIA GPUs using GraalVM 23.1.0 JDK21
+## OpenCL Backend only
+
+FROM ubuntu:22.04
+
+LABEL MAINTAINER Thanos Stratikopoulos <athanasios.stratikopoulos@manchester.ac.uk>
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update -q && apt-get install -qy \
+        build-essential vim git cmake maven openjdk-17-jdk python3 python3-pip \
+        libyaml-dev make gcc libssl-dev ninja-build \
+        wget clinfo ocl-icd-opencl-dev opencl-headers && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install wget
+# TruffleRuby dependency
+RUN python3 -m pip install ninja_syntax
+
+ENV PATH /usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
+
+# Enable Nvidia OpenCLmx/mx --dynamicimports /compiler build
+RUN mkdir -p /etc/OpenCL/vendors && \
+    echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+# Install TruffleRuby
+WORKDIR /truffleruby-dev/
+RUN git clone https://github.com/oracle/graal /truffleruby-dev/graal && cd /truffleruby-dev/graal && git checkout 39e46e0bc2bd49cb52f3c98944253d59d76a21b0
+RUN git clone https://github.com/oracle/truffleruby.git /truffleruby-dev/truffleruby && cd /truffleruby-dev/truffleruby && git checkout graal-23.1.0
+WORKDIR /truffleruby-dev/truffleruby
+RUN git clone https://github.com/graalvm/mx.git /truffleruby-dev/mx
+RUN wget -O /tmp/labsjdk-ce-21.0.1+12-jvmci-23.1-b22-linux-amd64.tar.gz https://github.com/graalvm/labs-openjdk-21/releases/download/jvmci-23.1-b22/labsjdk-ce-21.0.1+12-jvmci-23.1-b22-linux-amd64.tar.gz
+RUN mkdir -p /root/.mx/jdks/ \
+    && tar xzvf /tmp/labsjdk-ce-21.0.1+12-jvmci-23.1-b22-linux-amd64.tar.gz --directory /root/.mx/jdks/
+ENV MX_PYTHON_VERSION=3
+WORKDIR /truffleruby-dev/truffleruby
+ENV JAVA_HOME=/root/.mx/jdks/labsjdk-ce-21.0.1-jvmci-23.1-b22
+RUN /truffleruby-dev/mx/mx sforceimports
+RUN /truffleruby-dev/mx/mx --dynamicimports /compiler build
+
+## Install TornadoVM 
+WORKDIR /tornado-dev/
+RUN git clone https://github.com/beehive-lab/TornadoVM.git tornado && cd tornado && git checkout master
+WORKDIR /tornado-dev/tornado
+ENV CMAKE_ROOT=/usr
+RUN ./bin/tornadovm-installer --jdk graalvm-jdk-21 --backend opencl --polyglot 
+SHELL ["/bin/bash", "-c", "source /tornado/tornado/setvars.sh"]
+
+## ENV-Variables Taken from the SOURCE.sh
+ENV JAVA_HOME=/tornado-dev/tornado/etc/dependencies/TornadoVM-graalvm-jdk-21/graalvm-community-openjdk-21.0.1+12.1
+ENV PATH=/tornado-dev/tornado/bin/bin:$PATH
+ENV TORNADO_SDK=/tornado-dev/tornado/bin/sdk
+ENV TORNADO_ROOT=/tornado-dev/tornado 
+ENV TRUFFLERUBY_HOME=/truffleruby-dev/graal/sdk/mxbuild/linux-amd64/GRAALVM_AEA5C30A3B_JAVA21/graalvm-aea5c30a3b-java21-23.1.0-dev
+
+## Final Setup
+WORKDIR /data
+VOLUME ["/data"]
+EXPOSE 3000 

--- a/polyglotImages/polyglot-truffleruby/tornadovm-polyglot.sh
+++ b/polyglotImages/polyglot-truffleruby/tornadovm-polyglot.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [[ "$1" == "--console" ]]; then
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container
+elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
+    echo "Please run:"
+    echo "  ./tornadovm-polyglot.sh --console		to launch the built image in which TruffleRuby interoperates with TornadoVM, or"
+    echo "  ./tornadovm-polyglot.sh <command>		to launch the built image or execute a Ruby program that interoperates with TornadoVM, or"
+    echo "  ./tornadovm-polyglot.sh --help		to print help message"
+else
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container "$@"
+fi

--- a/polyglotImages/polyglot-truffleruby/tornadovm-polyglot.sh
+++ b/polyglotImages/polyglot-truffleruby/tornadovm-polyglot.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 if [[ "$1" == "--console" ]]; then
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container:latest
 elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
     echo "Please run:"
     echo "  ./tornadovm-polyglot.sh --console		to launch the built image in which TruffleRuby interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh <command>		to launch the built image or execute a Ruby program that interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh --help		to print help message"
 else
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container "$@"
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container:latest "$@"
 fi

--- a/polyglotImages/polyglot-truffleruby/tornadovm-polyglot.sh
+++ b/polyglotImages/polyglot-truffleruby/tornadovm-polyglot.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 if [[ "$1" == "--console" ]]; then
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container:latest
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v "$PWD":/data beehivelab/tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container:latest
 elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
     echo "Please run:"
     echo "  ./tornadovm-polyglot.sh --console		to launch the built image in which TruffleRuby interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh <command>		to launch the built image or execute a Ruby program that interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh --help		to print help message"
 else
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container:latest "$@"
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v "$PWD":/data beehivelab/tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container:latest "$@"
 fi

--- a/polyglotImages/polyglot-truffleruby/tornadovm-polyglot.sh
+++ b/polyglotImages/polyglot-truffleruby/tornadovm-polyglot.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 if [[ "$1" == "--console" ]]; then
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container
 elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
     echo "Please run:"
     echo "  ./tornadovm-polyglot.sh --console		to launch the built image in which TruffleRuby interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh <command>		to launch the built image or execute a Ruby program that interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot.sh --help		to print help message"
 else
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container "$@"
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v data:/data beehivelab/tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container "$@"
 fi


### PR DESCRIPTION
### This is ready for review.

In this PR I have added the following:

- Docker files that build `TornadoVM` with `GraalPy, GraalJS, TruffleRuby` and OpenCL drivers for NVIDIA GPUs.
- Building scripts to build the images.
- Documentation (`README.md`) to try and use the polyglot docker images of TornadoVM.

#### To build all images, try:
```bash
./buildDocker.sh --all
```

You can also pull the images from docker hub:
* For the `tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container` image:
```bash
$ docker pull beehivelab/tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container:latest
```

* For the `tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container` image:
```bash
$ docker pull beehivelab/tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container:latest
```

* For the `tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container` image:
```bash
$ docker pull beehivelab/tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container:latest
```

#### To run the example:
```bash
./polyglot-graalpy/tornadovm-polyglot.sh tornado --printKernel --truffle python /tornado-dev/tornado/bin/sdk/examples/polyglotTruffle/mxmWithTornadoVM.py
```