### PR TITLE
New docker file for TornadoVM graalpy running on Intel hardware and update of running scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,11 +178,17 @@ We provide a runner script for each image in order to compile and run your Pytho
 $ git clone https://github.com/beehive-lab/docker-tornadovm
 $ cd docker-tornadovm
 
-## Launch the docker image
-$ ./polyglotImages/polyglot-graalpy/tornadovm-polyglot.sh
+## Launch the docker image with the NVIDIA OpenCL runtime
+$ ./polyglotImages/polyglot-graalpy/tornadovm-polyglot-nvidia.sh
 
 ## Run Matrix Multiplication from a Python program.
-$ ./polyglotImages/polyglot-graalpy/tornadovm-polyglot.sh tornado --printKernel --truffle python example/polyglot-examples/mxmWithTornadoVM.py
+$ ./polyglotImages/polyglot-graalpy/tornadovm-polyglot-nvidia.sh tornado --printKernel --truffle python example/polyglot-examples/mxmWithTornadoVM.py
+
+## Launch the docker image with the Intel oneAPI runtime
+$ ./polyglotImages/polyglot-graalpy/tornadovm-polyglot-intel.sh
+
+## Run Matrix Multiplication from a Python program.
+$ ./polyglotImages/polyglot-graalpy/tornadovm-polyglot-intel.sh tornado --printKernel --truffle python example/polyglot-examples/mxmWithTornadoVM.py
 ```
 
 * JavaScript:
@@ -190,7 +196,7 @@ $ ./polyglotImages/polyglot-graalpy/tornadovm-polyglot.sh tornado --printKernel 
 $ git clone https://github.com/beehive-lab/docker-tornadovm
 $ cd docker-tornadovm
 
-## Launch the docker image
+## Launch the docker image with the NVIDIA OpenCL runtime
 $ ./polyglotImages/polyglot-graaljs/tornadovm-polyglot.sh
 
 ## Run Matrix Multiplication from a JavaScript program.
@@ -202,7 +208,7 @@ $ ./polyglotImages/polyglot-graaljs/tornadovm-polyglot.sh tornado --printKernel 
 $ git clone https://github.com/beehive-lab/docker-tornadovm
 $ cd docker-tornadovm
 
-## Launch the docker image
+## Launch the docker image with the NVIDIA OpenCL runtime
 $ ./polyglotImages/polyglot-truffleruby/tornadovm-polyglot.sh
 
 ## Run Matrix Multiplication from a Python program.

--- a/polyglotImages/README.md
+++ b/polyglotImages/README.md
@@ -23,7 +23,7 @@ To build all images, try:
 ## Run examples
 To run an example of a Python program from [here](https://github.com/beehive-lab/TornadoVM/blob/master/tornado-assembly/src/examples/polyglotTruffle/mxmWithTornadoVM.py) in the container with TornadoVM use:
 ```bash
-./polyglot-graalpy/tornadovm-polyglot.sh tornado --printKernel --truffle python /tornado-dev/tornado/bin/sdk/examples/polyglotTruffle/mxmWithTornadoVM.py
+./polyglot-graalpy/tornadovm-polyglot-nvidia.sh tornado --printKernel --truffle python /tornado-dev/tornado/bin/sdk/examples/polyglotTruffle/mxmWithTornadoVM.py
 ```
 The output will be:
 ```bash

--- a/polyglotImages/buildDocker.sh
+++ b/polyglotImages/buildDocker.sh
@@ -13,7 +13,7 @@ function buildDockerImage() {
 
 if [[ "$1" == "--python" ]]; then
     docker volume create data
-    #buildDockerImage "tornadovm-polyglot-graalpy-23.1.0-oneapi-intel-container" "./polyglot-graalpy/Dockerfile.intel.oneapi.graalpy.jdk21"
+    buildDockerImage "tornadovm-polyglot-graalpy-23.1.0-oneapi-intel-container" "./polyglot-graalpy/Dockerfile.intel.oneapi.graalpy.jdk21"
     buildDockerImage "tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container" "./polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21"
 elif [[ "$1" == "--js" ]]; then
     docker volume create data

--- a/polyglotImages/buildDocker.sh
+++ b/polyglotImages/buildDocker.sh
@@ -13,7 +13,7 @@ function buildDockerImage() {
 
 if [[ "$1" == "--python" ]]; then
     docker volume create data
-    buildDockerImage "tornadovm-polyglot-graalpy-23.1.0-oneapi-intel-container" "./polyglot-graalpy/Dockerfile.intel.oneapi.graalpy.jdk21"
+    #buildDockerImage "tornadovm-polyglot-graalpy-23.1.0-oneapi-intel-container" "./polyglot-graalpy/Dockerfile.intel.oneapi.graalpy.jdk21"
     buildDockerImage "tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container" "./polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21"
 elif [[ "$1" == "--js" ]]; then
     docker volume create data
@@ -25,6 +25,7 @@ elif [[ "$1" == "--deleteVolume" ]]; then
     docker volume rm data
 elif [[ "$1" == "--all" ]]; then
     docker volume create data
+    buildDockerImage "tornadovm-polyglot-graalpy-23.1.0-oneapi-intel-container" "./polyglot-graalpy/Dockerfile.intel.oneapi.graalpy.jdk21"
     buildDockerImage "tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container" "./polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21"
     buildDockerImage "tornadovm-polyglot-graaljs-23.1.0-nvidia-opencl-container" "./polyglot-graaljs/Dockerfile.nvidia.opencl.graaljs.jdk21"
     buildDockerImage "tornadovm-polyglot-truffleruby-23.1.0-nvidia-opencl-container" "./polyglot-truffleruby/Dockerfile.nvidia.opencl.truffleruby.jdk21"

--- a/polyglotImages/buildDocker.sh
+++ b/polyglotImages/buildDocker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAG_VERSION=0.15.2-dev
+TAG_VERSION=1.0.4-dev
 
 function buildDockerImage() {
     IMAGE=$1
@@ -13,6 +13,7 @@ function buildDockerImage() {
 
 if [[ "$1" == "--python" ]]; then
     docker volume create data
+    buildDockerImage "tornadovm-polyglot-graalpy-23.1.0-oneapi-intel-container" "./polyglot-graalpy/Dockerfile.intel.oneapi.graalpy.jdk21"
     buildDockerImage "tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container" "./polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21"
 elif [[ "$1" == "--js" ]]; then
     docker volume create data

--- a/polyglotImages/polyglot-graalpy/Dockerfile.intel.oneapi.graalpy.jdk21
+++ b/polyglotImages/polyglot-graalpy/Dockerfile.intel.oneapi.graalpy.jdk21
@@ -1,0 +1,55 @@
+FROM intel/oneapi-basekit
+
+LABEL MAINTAINER Thanos Stratikopoulos <athanasios.stratikopoulos@manchester.ac.uk>
+
+RUN apt-get update -q && apt-get install -qy \
+        python3 build-essential vim git cmake maven openjdk-17-jdk python3-pip \
+        wget && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install wget
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+## OpenCL configuration
+RUN apt-get update && apt-get install -y opencl-headers
+RUN ln -s /usr/lib/x86_64-linux-gnu/libOpenCL.so.1 /usr/lib/x86_64-linux-gnu/libOpenCL.so
+ENV OpenCL_LIBRARY /usr/lib/x86_64-linux-gnu/libOpenCL.so.1
+
+RUN java -version
+RUN javac -version
+
+ENV PATH /usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
+
+# Install GraalPy
+WORKDIR /graalpy-dev/
+RUN git clone https://github.com/oracle/graal /graalpy-dev/graal && cd /graalpy-dev/graal && git checkout 5a21d6dd0051ff99f561d89dfc530d723edb3ab8
+RUN git clone https://github.com/oracle/graalpython.git /graalpy-dev/graalpython && cd /graalpy-dev/graalpython && git checkout graal-23.1.0
+WORKDIR /graalpy-dev/graalpython
+RUN git clone https://github.com/graalvm/mx.git /graalpy-dev/graalpython/mx
+RUN wget -O /tmp/labsjdk-ce-21.0.1+12-jvmci-23.1-b22-linux-amd64.tar.gz https://github.com/graalvm/labs-openjdk-21/releases/download/jvmci-23.1-b22/labsjdk-ce-21.0.1+12-jvmci-23.1-b22-linux-amd64.tar.gz
+RUN mkdir -p /root/.mx/jdks/ \
+    && tar xzvf /tmp/labsjdk-ce-21.0.1+12-jvmci-23.1-b22-linux-amd64.tar.gz --directory /root/.mx/jdks/
+ENV MX_PYTHON_VERSION=3
+WORKDIR /graalpy-dev/graalpython/
+ENV JAVA_HOME=/root/.mx/jdks/labsjdk-ce-21.0.1-jvmci-23.1-b22
+RUN mx/mx --dy /compiler python-gvm
+
+## Install TornadoVM 
+WORKDIR /tornado-dev/
+RUN git clone https://github.com/beehive-lab/TornadoVM.git tornado && cd tornado && git checkout master
+WORKDIR /tornado-dev/tornado
+ENV CMAKE_ROOT=/usr
+RUN ./bin/tornadovm-installer --jdk graalvm-jdk-21 --backend opencl --polyglot 
+SHELL ["/bin/bash", "-c", "source /tornado/tornado/setvars.sh"]
+
+## ENV-Variables Taken from the SOURCE.sh
+ENV JAVA_HOME=/tornado-dev/tornado/etc/dependencies/TornadoVM-graalvm-jdk-21/graalvm-community-openjdk-21.0.1+12.1
+ENV PATH=/tornado-dev/tornado/bin/bin:$PATH
+ENV TORNADO_SDK=/tornado-dev/tornado/bin/sdk
+ENV TORNADO_ROOT=/tornado-dev/tornado 
+ENV GRAALPY_HOME=/graalpy-dev/graal/sdk/mxbuild/linux-amd64/GRAALVM_03DCD25EA1_JAVA21/graalvm-03dcd25ea1-java21-23.1.0-dev
+ENV DOCKER_FPGA_EMULATION=1 
+
+WORKDIR /data
+VOLUME ["/data"]

--- a/polyglotImages/polyglot-graalpy/Dockerfile.intel.oneapi.graalpy.jdk21
+++ b/polyglotImages/polyglot-graalpy/Dockerfile.intel.oneapi.graalpy.jdk21
@@ -3,7 +3,7 @@ FROM intel/oneapi-basekit
 LABEL MAINTAINER Thanos Stratikopoulos <athanasios.stratikopoulos@manchester.ac.uk>
 
 RUN apt-get update -q && apt-get install -qy \
-        python3 build-essential vim git cmake maven openjdk-17-jdk python3-pip \
+        python3 build-essential vim git cmake maven file openjdk-17-jdk python3-pip \
         wget && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install wget

--- a/polyglotImages/polyglot-graalpy/tornadovm-polyglot-intel.sh
+++ b/polyglotImages/polyglot-graalpy/tornadovm-polyglot-intel.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [[ "$1" == "--console" ]]; then
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v "$PWD":/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-oneapi-intel-container:latest
+elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
+    echo "Please run:"
+    echo "  ./tornadovm-polyglot-intel.sh --console		to launch the built image in which GraalPy interoperates with TornadoVM, or"
+    echo "  ./tornadovm-polyglot-intel.sh <command>		to launch the built image or execute a Python program that interoperates with TornadoVM, or"
+    echo "  ./tornadovm-polyglot-intel.sh --help		to print help message"
+else
+    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v "$PWD":/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-oneapi-intel-container:latest "$@"
+fi

--- a/polyglotImages/polyglot-graalpy/tornadovm-polyglot-intel.sh
+++ b/polyglotImages/polyglot-graalpy/tornadovm-polyglot-intel.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 if [[ "$1" == "--console" ]]; then
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v "$PWD":/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-oneapi-intel-container:latest
+    docker run -it --device /dev/dri:/dev/dri -p 8080:8080 --rm --gpus all -v "$PWD":/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-oneapi-intel-container:latest
 elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
     echo "Please run:"
     echo "  ./tornadovm-polyglot-intel.sh --console		to launch the built image in which GraalPy interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot-intel.sh <command>		to launch the built image or execute a Python program that interoperates with TornadoVM, or"
     echo "  ./tornadovm-polyglot-intel.sh --help		to print help message"
 else
-    docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v "$PWD":/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-oneapi-intel-container:latest "$@"
+    docker run -it --device /dev/dri:/dev/dri -p 8080:8080 --rm --gpus all -v "$PWD":/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-oneapi-intel-container:latest "$@"
 fi

--- a/polyglotImages/polyglot-graalpy/tornadovm-polyglot-nvidia.sh
+++ b/polyglotImages/polyglot-graalpy/tornadovm-polyglot-nvidia.sh
@@ -4,9 +4,9 @@ if [[ "$1" == "--console" ]]; then
     docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v "$PWD":/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container:latest
 elif [[ "$1" == "--help" ]] || [[ "$1" == "--h" ]]; then
     echo "Please run:"
-    echo "  ./tornadovm-polyglot.sh --console		to launch the built image in which GraalPy interoperates with TornadoVM, or"
-    echo "  ./tornadovm-polyglot.sh <command>		to launch the built image or execute a Python program that interoperates with TornadoVM, or"
-    echo "  ./tornadovm-polyglot.sh --help		to print help message"
+    echo "  ./tornadovm-polyglot-nvidia.sh --console		to launch the built image in which GraalPy interoperates with TornadoVM, or"
+    echo "  ./tornadovm-polyglot-nvidia.sh <command>		to launch the built image or execute a Python program that interoperates with TornadoVM, or"
+    echo "  ./tornadovm-polyglot-nvidia.sh --help		to print help message"
 else
     docker run -it -p 8080:8080 --rm --runtime=nvidia --gpus all -v "$PWD":/data beehivelab/tornadovm-polyglot-graalpy-23.1.0-nvidia-opencl-container:latest "$@"
 fi


### PR DESCRIPTION
This PR contains:

1. A new docker image for Intel hardware: [polyglotImages/polyglot-graalpy/Dockerfile.intel.oneapi.graalpy.jdk21](https://github.com/beehive-lab/docker-tornadovm/compare/master...TANGO-EU-PROJECT:docker-tornadovm:feat/graalpy-oneapi?expand=1#diff-15695812493ddc1ab3d6bbc4baca6fbddd248cff4255aab28fb4bb5ec930d94d)
2. Update in the versioning of the containers that are pushed in docker hub. Current tag is `1.0.4-dev`, following the version of the master branch in TornadoVM.
3. Update in the runner scripts for the `graalpy` images. I split them in two separate commands:

- one for NVIDIA GPUs with OpenCL: `tornadovm-polyglot-nvidia.sh`
- a second for Intel hardware with OpenCL: `tornadovm-polyglot-intel.sh`

**How to test?**
* For the `tornadovm-polyglot-graalpy-23.1.0-oneapi-intel-container` image:
```bash
$ docker pull beehivelab/tornadovm-polyglot-graalpy-23.1.0-oneapi-intel-container:latest
$ ./polyglotImages/polyglot-graalpy/tornadovm-polyglot-intel.sh tornado --printKernel --truffle python example/polyglot-examples/mxmWithTornadoVM.py
$ ./polyglotImages/polyglot-graalpy/tornadovm-polyglot-intel.sh tornado --devices
```
