### PR TITLE
Updated docker images of TornadoVM v1.0.8 for execution with polyglot runtime systems

### DIFF
--- a/polyglotImages/buildDocker.sh
+++ b/polyglotImages/buildDocker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAG_VERSION=1.0.4-dev
+TAG_VERSION=1.0.8
 
 function buildDockerImage() {
     IMAGE=$1

--- a/polyglotImages/polyglot-graaljs/Dockerfile.nvidia.opencl.graaljs.jdk21
+++ b/polyglotImages/polyglot-graaljs/Dockerfile.nvidia.opencl.graaljs.jdk21
@@ -12,6 +12,7 @@ RUN apt-get update -q && apt-get install -qy \
         wget clinfo ocl-icd-opencl-dev opencl-headers && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install wget
+RUN python3 -m pip install psutil
 
 ENV PATH /usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH
 ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
@@ -41,7 +42,7 @@ WORKDIR /tornado-dev/
 RUN git clone https://github.com/beehive-lab/TornadoVM.git tornado && cd tornado && git checkout master
 WORKDIR /tornado-dev/tornado
 ENV CMAKE_ROOT=/usr
-RUN ./bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl --polyglot 
+RUN ./bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl
 SHELL ["/bin/bash", "-c", "source /tornado-dev/tornado/setvars.sh"]
 
 ## ENV-Variables Taken from the SOURCE.sh

--- a/polyglotImages/polyglot-graaljs/Dockerfile.nvidia.opencl.graaljs.jdk21
+++ b/polyglotImages/polyglot-graaljs/Dockerfile.nvidia.opencl.graaljs.jdk21
@@ -41,11 +41,11 @@ WORKDIR /tornado-dev/
 RUN git clone https://github.com/beehive-lab/TornadoVM.git tornado && cd tornado && git checkout master
 WORKDIR /tornado-dev/tornado
 ENV CMAKE_ROOT=/usr
-RUN ./bin/tornadovm-installer --jdk graalvm-jdk-21 --backend opencl --polyglot 
-SHELL ["/bin/bash", "-c", "source /tornado/tornado/setvars.sh"]
+RUN ./bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl --polyglot 
+SHELL ["/bin/bash", "-c", "source /tornado-dev/tornado/setvars.sh"]
 
 ## ENV-Variables Taken from the SOURCE.sh
-ENV JAVA_HOME=/tornado-dev/tornado/etc/dependencies/TornadoVM-graalvm-jdk-21/graalvm-community-openjdk-21.0.1+12.1
+ENV JAVA_HOME=/tornado-dev/tornado/etc/dependencies/TornadoVM-graal-jdk-21/graalvm-community-openjdk-21.0.1+12.1
 ENV PATH=/tornado-dev/tornado/bin/bin:$PATH
 ENV TORNADO_SDK=/tornado-dev/tornado/bin/sdk
 ENV TORNADO_ROOT=/tornado-dev/tornado 

--- a/polyglotImages/polyglot-graalpy/Dockerfile.intel.oneapi.graalpy.jdk21
+++ b/polyglotImages/polyglot-graalpy/Dockerfile.intel.oneapi.graalpy.jdk21
@@ -40,7 +40,7 @@ WORKDIR /tornado-dev/
 RUN git clone https://github.com/beehive-lab/TornadoVM.git tornado && cd tornado && git checkout master
 WORKDIR /tornado-dev/tornado
 ENV CMAKE_ROOT=/usr
-RUN ./bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl --polyglot 
+RUN ./bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl 
 SHELL ["/bin/bash", "-c", "source /tornado-dev/tornado/setvars.sh"]
 
 ## ENV-Variables Taken from the SOURCE.sh

--- a/polyglotImages/polyglot-graalpy/Dockerfile.intel.oneapi.graalpy.jdk21
+++ b/polyglotImages/polyglot-graalpy/Dockerfile.intel.oneapi.graalpy.jdk21
@@ -40,11 +40,11 @@ WORKDIR /tornado-dev/
 RUN git clone https://github.com/beehive-lab/TornadoVM.git tornado && cd tornado && git checkout master
 WORKDIR /tornado-dev/tornado
 ENV CMAKE_ROOT=/usr
-RUN ./bin/tornadovm-installer --jdk graalvm-jdk-21 --backend opencl --polyglot 
-SHELL ["/bin/bash", "-c", "source /tornado/tornado/setvars.sh"]
+RUN ./bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl --polyglot 
+SHELL ["/bin/bash", "-c", "source /tornado-dev/tornado/setvars.sh"]
 
 ## ENV-Variables Taken from the SOURCE.sh
-ENV JAVA_HOME=/tornado-dev/tornado/etc/dependencies/TornadoVM-graalvm-jdk-21/graalvm-community-openjdk-21.0.1+12.1
+ENV JAVA_HOME=/tornado-dev/tornado/etc/dependencies/TornadoVM-graal-jdk-21/graalvm-community-openjdk-21.0.1+12.1
 ENV PATH=/tornado-dev/tornado/bin/bin:$PATH
 ENV TORNADO_SDK=/tornado-dev/tornado/bin/sdk
 ENV TORNADO_ROOT=/tornado-dev/tornado 

--- a/polyglotImages/polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21
+++ b/polyglotImages/polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21
@@ -42,7 +42,7 @@ WORKDIR /tornado-dev/
 RUN git clone https://github.com/beehive-lab/TornadoVM.git tornado && cd tornado && git checkout master
 WORKDIR /tornado-dev/tornado
 ENV CMAKE_ROOT=/usr
-RUN ./bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl --polyglot 
+RUN ./bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl 
 SHELL ["/bin/bash", "-c", "source /tornado-dev/tornado/setvars.sh"]
 
 ## ENV-Variables Taken from the SOURCE.sh

--- a/polyglotImages/polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21
+++ b/polyglotImages/polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21
@@ -42,11 +42,11 @@ WORKDIR /tornado-dev/
 RUN git clone https://github.com/beehive-lab/TornadoVM.git tornado && cd tornado && git checkout master
 WORKDIR /tornado-dev/tornado
 ENV CMAKE_ROOT=/usr
-RUN ./bin/tornadovm-installer --jdk graalvm-jdk-21 --backend opencl --polyglot 
-SHELL ["/bin/bash", "-c", "source /tornado/tornado/setvars.sh"]
+RUN ./bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl --polyglot 
+SHELL ["/bin/bash", "-c", "source /tornado-dev/tornado/setvars.sh"]
 
 ## ENV-Variables Taken from the SOURCE.sh
-ENV JAVA_HOME=/tornado-dev/tornado/etc/dependencies/TornadoVM-graalvm-jdk-21/graalvm-community-openjdk-21.0.1+12.1
+ENV JAVA_HOME=/tornado-dev/tornado/etc/dependencies/TornadoVM-graal-jdk-21/graalvm-community-openjdk-21.0.1+12.1
 ENV PATH=/tornado-dev/tornado/bin/bin:$PATH
 ENV TORNADO_SDK=/tornado-dev/tornado/bin/sdk
 ENV TORNADO_ROOT=/tornado-dev/tornado 

--- a/polyglotImages/polyglot-truffleruby/Dockerfile.nvidia.opencl.truffleruby.jdk21
+++ b/polyglotImages/polyglot-truffleruby/Dockerfile.nvidia.opencl.truffleruby.jdk21
@@ -45,11 +45,11 @@ WORKDIR /tornado-dev/
 RUN git clone https://github.com/beehive-lab/TornadoVM.git tornado && cd tornado && git checkout master
 WORKDIR /tornado-dev/tornado
 ENV CMAKE_ROOT=/usr
-RUN ./bin/tornadovm-installer --jdk graalvm-jdk-21 --backend opencl --polyglot 
-SHELL ["/bin/bash", "-c", "source /tornado/tornado/setvars.sh"]
+RUN ./bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl --polyglot 
+SHELL ["/bin/bash", "-c", "source /tornado-dev/tornado/setvars.sh"]
 
 ## ENV-Variables Taken from the SOURCE.sh
-ENV JAVA_HOME=/tornado-dev/tornado/etc/dependencies/TornadoVM-graalvm-jdk-21/graalvm-community-openjdk-21.0.1+12.1
+ENV JAVA_HOME=/tornado-dev/tornado/etc/dependencies/TornadoVM-graal-jdk-21/graalvm-community-openjdk-21.0.1+12.1
 ENV PATH=/tornado-dev/tornado/bin/bin:$PATH
 ENV TORNADO_SDK=/tornado-dev/tornado/bin/sdk
 ENV TORNADO_ROOT=/tornado-dev/tornado 

--- a/polyglotImages/polyglot-truffleruby/Dockerfile.nvidia.opencl.truffleruby.jdk21
+++ b/polyglotImages/polyglot-truffleruby/Dockerfile.nvidia.opencl.truffleruby.jdk21
@@ -42,7 +42,7 @@ RUN /truffleruby-dev/mx/mx --dynamicimports /compiler build
 
 ## Install TornadoVM 
 WORKDIR /tornado-dev/
-RUN git clone https://github.com/beehive-lab/TornadoVM.git tornado && cd tornado && git checkout master
+RUN git clone https://github.com/beehive-lab/TornadoVM.git tornado && cd tornado && git checkout v1.0.8
 WORKDIR /tornado-dev/tornado
 ENV CMAKE_ROOT=/usr
 RUN ./bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl 

--- a/polyglotImages/polyglot-truffleruby/Dockerfile.nvidia.opencl.truffleruby.jdk21
+++ b/polyglotImages/polyglot-truffleruby/Dockerfile.nvidia.opencl.truffleruby.jdk21
@@ -45,7 +45,7 @@ WORKDIR /tornado-dev/
 RUN git clone https://github.com/beehive-lab/TornadoVM.git tornado && cd tornado && git checkout master
 WORKDIR /tornado-dev/tornado
 ENV CMAKE_ROOT=/usr
-RUN ./bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl --polyglot 
+RUN ./bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl 
 SHELL ["/bin/bash", "-c", "source /tornado-dev/tornado/setvars.sh"]
 
 ## ENV-Variables Taken from the SOURCE.sh


### PR DESCRIPTION
This PR contains small changes in the docker files of the polyglot images to run Python, JavaScript and Ruby with the GraalVM polyglot runtime implementations.

The changes regards:
1. Building TornadoVM without the `polyglot` flag which enables Python, JavaScript and R to be written in a Java class. Those dependencies increase the size of the docker containers, and they are not useful since someone can use them in a local implementation. If a user of the containers requires them, we can revert it at the cost of the size of containers.
2. Update the tag version of the containers.